### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Connect to my.jdownloader.org
 
     $j = new MYJDAPI();
     $j -> connect( "EMAIL", "PASSWORD");
+    $j -> setDeviceName("YOUR_DEVICE_NAME");
 ?>
 ```
 
@@ -39,12 +40,12 @@ or use this method to initialize the class
 <?php
     require_once 'myjdapi_class.php';
 
-    $j = new MYJDAPI( "EMAIL", "PASSWORD");
+    $j = new MYJDAPI( "EMAIL", "PASSWORD", "YOUR_DEVICE_NAME");
 ?>
 ```
 
 Available methods:  connect, reconnect, disconnect, enumerateDevices,
-getDirectConnectionInfos, callAction, addLinks, and more maybe later.
+getDirectConnectionInfos, callAction, addLinks, queryLinks and more maybe later.
 
 Add links to jdownloader and start it
 
@@ -52,11 +53,19 @@ Add links to jdownloader and start it
 <?php
     require_once 'myjdapi_class.php';
 
-    $j = new MYJDAPI( "EMAIL", "PASSWORD");
-    $j -> addLinks( "YOUR_DEVICE_NAME", "LINKS", "PACKAGE_NAME");
+    $j = new MYJDAPI( "EMAIL", "PASSWORD", "YOUR_DEVICE_NAME");
+    $j -> addLinks("LINKS", "PACKAGE_NAME");
 ?>
 ```
 
+```php
+<?php
+    require_once 'myjdapi_class.php';
+
+    $j = new MYJDAPI( "EMAIL", "PASSWORD", "YOUR_DEVICE_NAME");
+    $j -> queryLinks();
+?>
+```
 Copyright (c) 2014 Anatoliy Kultenko "tofik".
 
 Released under the BSD License, see http://opensource.org/licenses/BSD-3-Clause

--- a/myjdapi_class.php
+++ b/myjdapi_class.php
@@ -166,22 +166,25 @@ class MYJDAPI
 
     // Retrive links
     public function queryLinks($params = []) {
-        //taken from: https://github.com/mmarquezs/My.Jdownloader-API-Python-Library/blob/master/myjdapi.py
+        //taken from: https://docs.google.com/document/d/1IGeAwg8bQyaCTeTl_WyjLyBPh4NBOayO0_MAmvP5Mu4/edit# (LinkQueryStorable)
         $params_default = [
-            "bytesTotal"    => True,
-            "comment"       => True,
-            "status"        => True,
-            "enabled"       => True,
-            "maxResults"    => -1,
-            "startAt"       => 0,
-            "hosts"         => True,
-            "url"           => True,
-            "availability"  => True,
-            "variantIcon"   => True,
-            "variantName"   => True,
-            "variantID"     => True,
-            "variants"      => True,
-            "priority"      => True
+            "bytesTotal" => true,
+            "comment" => true,
+            "status" => true,
+            "enabled" => true,
+            "maxResults" => -1,
+            "startAt" => 0,
+            "packageUUIDs" => null,
+            "host" => true,
+            "url" => true,
+            "bytesLoaded" => true,
+            "speed" => true,
+            "eta" => true,
+            "finished" => true,
+            "priority" => true,
+            "running" => true,
+            "skipped" => true,
+            "extractionStatus" => true
         ];
 
         $params = array_merge($params_default, $params);


### PR DESCRIPTION
Allow array for "params" in callAction
Use HTTPS for jdownload API
addLinks, "$package_name" can be null and put null by default
Add "queryLinks" to retrive current download list
Add "setDeviceName" and "getDeviceName"
Remove "device" param from "addLinks
Adding Third params to constructor to pass default device name